### PR TITLE
Support locating the Tiller pod in a Kubernetes cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ script:
 - dotnet build --no-restore -c Release
 - dotnet pack --no-restore -c Release
 - dotnet test Helm.Tests
+- cat $KUBECONFIG
 - dotnet test Helm.IntegrationTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
 - ci/install.sh
 
 script:
+- sed -i .bak 's/as-user-extra/#as-user-extra/' $KUBECONFIG
 - dotnet restore src/Helm.sln
 - cd proto
 - ./generate.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ script:
 - cd ../src
 - dotnet build --no-restore -c Release
 - dotnet pack --no-restore -c Release
+- dotnet test Helm.Tests
+- dotnet test Helm.IntegrationTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 
 before_script:
 - ci/install.sh
-- kubectl cluster-infox
+- kubectl cluster-info
 
 script:
 - sed -i.bak 's/as-user-extra/#as-user-extra/' $KUBECONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ env:
 
 before_script:
 - ci/install.sh
-- kubectl cluster-info
-- kubectl get pods --all-namespaces
+- kubectl cluster-info dump
 
 script:
 - sed -i.bak 's/as-user-extra/#as-user-extra/' $KUBECONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 - ci/install.sh
 
 script:
-- sed -i .bak 's/as-user-extra/#as-user-extra/' $KUBECONFIG
+- sed -i.bak 's/as-user-extra/#as-user-extra/' $KUBECONFIG
 - dotnet restore src/Helm.sln
 - cd proto
 - ./generate.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 
 before_script:
 - ci/install.sh
+- kubectl cluster-info
 - kubectl get pods --all-namespaces
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 
 before_script:
 - ci/install.sh
-- kubectl cluster-info dump
+- kubectl cluster-infox
 
 script:
 - sed -i.bak 's/as-user-extra/#as-user-extra/' $KUBECONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
     - MINIKUBE_WANTREPORTERRORPROMPT=false
     - MINIKUBE_WANTUPDATENOTIFICATION=false
+    - KUBECONFIG=/home/travis/.kube/config
 
 before_script:
 - ci/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 
 before_script:
 - ci/install.sh
+- kubectl get pods --all-namespaces
 
 script:
 - sed -i.bak 's/as-user-extra/#as-user-extra/' $KUBECONFIG

--- a/README.md
+++ b/README.md
@@ -1,6 +1,49 @@
 # .NET Client for Helm
-[![Build status](https://ci.appveyor.com/api/projects/status/vsb2f1g32cj25h51/branch/master?svg=true)](https://ci.appveyor.com/project/qmfrederik/helm/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/vsb2f1g32cj25h51/branch/master?svg=true)](https://ci.appveyor.com/project/qmfrederik/helm/branch/master) [![Build Status](https://travis-ci.org/qmfrederik/helm.svg?branch=master)](https://travis-ci.org/qmfrederik/helm)
 
 [Helm](https://helm.sh/) is a package manager for Kubernetes. It allows you to install and use software built for Kubernetes.
 
 This repository contains a C# client for working with Helm.
+
+## Getting started
+Before you start, add the [Helm NuGet package](https://www.nuget.org/packages/Helm/) to your project and make sure you've initialized
+Helm inside your Kubernetes cluster.
+
+Helm uses a Tiller pod deployed in your Kubernetes cluster to manage charts and deployments.
+
+This means that you'll need to locate your Kubernetes cluster and the Tiller pod if you want to interact with it using C#.
+
+Here's how you can do that:
+
+```csharp
+// Open the Kubernetes configuration and connect to the Kubernetes cluster.
+// You may have a KUBECONFIG environment variable. If so, you're in luck - that's what we use in this sample app.
+// You Kubernetes configuration can also be stored at ~/.kube/config.
+var kubeConfig = KubernetesClientConfiguration.BuildConfigFromConfigFile(null, Environment.GetEnvironmentVariable("KUBECONFIG"));
+var kubernetes = new Kubernetes(kubeConfig);
+
+// Figure out where Tiller is located. This will return the IP address and port of a pod running Tiller.
+// The code assumes you can connect to a pod using it's IP address. That usually means your code is either running inside a pod,
+// or you've configured routing to your pod network.
+// If that's not the case, you'll need to set up Kubernetes port forwarding.
+TillerLocator locator = new TillerLocator(kubernetes);
+var endPoint = locator.Locate();
+
+// Connect to Tiller and get the version information
+using(var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+{
+    await socket.ConnectAsync(endPoint).ConfigureAwait(false);
+
+    using (NetworkStream stream = new NetworkStream(socket))
+    {
+        TillerClient client = new TillerClient(stream);
+        var version = await client.GetVersionAsync();
+    }
+}
+```
+
+## How it works
+The Helm client consists of three blocks:
+- A locator which helps you locate the Tiller pod in a Kubernetes cluster
+- C# code for the Helm protobuf protocol. This protocol defines how messages which are sent to and received from Helm are serialized.
+- A C# implementation of the gRPC protocol. This protocol allows to send and receive serialized messages over HTTP/2.

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -36,7 +36,7 @@ JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.ty
   until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
 # Initialize helm, with RBAC permissions
-kubectl create -f ~/ci/helm-rbac.yaml
+kubectl create -f $TRAVIS_BUILD_DIR/ci/helm-rbac.yaml
 helm init --service-account tiller
 
 # Wait for the Tiller pod to be online. helm init --wait has a timeout of 5 seconds, which is too

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -44,4 +44,4 @@ helm init --service-account tiller
 
 # Wait for the cluster to be ready
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \
-  until kubectl get pods -n kube-system -l app=helm,name=tiller -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do kubectl get pods -n kube-system; kubectl get pods -n kube-system -l app=helm,name=tiller; sleep 1; done
+  until kubectl get pods -n kube-system -l app=helm,name=tiller -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do kubectl get pods --all-namespaces; kubectl get pods -n kube-system -l app=helm,name=tiller; sleep 1; done

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -31,6 +31,9 @@ rm -rf ~/helm
 sudo minikube start --vm-driver=none --kubernetes-version=v1.9.0 --extra-config=apiserver.Authorization.Mode=RBAC
 minikube update-context
 
+# Disable the dashboard. We don't use it and it consumes a lot of resources
+minikube addons disable dashboard
+
 # Wait for the cluster nodes to be ready
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \
   until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -44,4 +44,4 @@ helm init --service-account tiller
 
 # Wait for the cluster to be ready
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \
-  until kubectl get pods -n kube-system -l app=helm,name=tiller -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do kubectl get pods -n kube-system; kubectl get pods -n kube-system -l app=helm,name=tiller; sleep 1 done
+  until kubectl get pods -n kube-system -l app=helm,name=tiller -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do kubectl get pods -n kube-system; kubectl get pods -n kube-system -l app=helm,name=tiller; sleep 1; done

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -44,4 +44,4 @@ helm init --service-account tiller
 
 # Wait for the cluster to be ready
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \
-  until kubectl get pods -n kube-system -l app=helm,name=tiller -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+  until kubectl get pods -n kube-system -l app=helm,name=tiller -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do kubectl get pods -n kube-system; kubectl get pods -n kube-system -l app=helm,name=tiller; sleep 1 done

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -31,10 +31,17 @@ rm -rf ~/helm
 sudo minikube start --vm-driver=none --kubernetes-version=v1.9.0 --extra-config=apiserver.Authorization.Mode=RBAC
 minikube update-context
 
-# Wait for the cluster to be ready
+# Wait for the cluster nodes to be ready
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \
   until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
 # Initialize helm, with RBAC permissions
 kubectl create -f ~/ci/helm-rbac.yaml
-helm init --service-account tiller --wait
+helm init --service-account tiller
+
+# Wait for the Tiller pod to be online. helm init --wait has a timeout of 5 seconds, which is too
+# optimistic for bootstrapping a cluster.
+
+# Wait for the cluster to be ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \
+  until kubectl get pods -n kube-system -l app=helm,name=tiller -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -37,4 +37,4 @@ JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.ty
 
 # Initialize helm, with RBAC permissions
 kubectl create -f ~/ci/helm-rbac.yaml
-helm init --service-account tiller
+helm init --service-account tiller --wait

--- a/src/Helm.IntegrationTests/.gitignore
+++ b/src/Helm.IntegrationTests/.gitignore
@@ -1,0 +1,4 @@
+# Kubernetes configuration files
+*.crt
+*.key
+*.config

--- a/src/Helm.IntegrationTests/Helm.IntegrationTests.csproj
+++ b/src/Helm.IntegrationTests/Helm.IntegrationTests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Helm\Helm.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- This allows you to put Kubernetes configuration files in the root directory of this project, and use the to connect
+         to a Kubernetes cluster of your choice for the integration tests. -->
+    <Content Include="*.crt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="*.key">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="*.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/src/Helm.IntegrationTests/TestConfiguration.cs
+++ b/src/Helm.IntegrationTests/TestConfiguration.cs
@@ -1,0 +1,48 @@
+﻿using Helm.Helm;
+using k8s;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Helm.IntegrationTests
+{
+    internal static class TestConfiguration
+    {
+        public static KubernetesClientConfiguration Configure()
+        {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("KUBECONFIG")))
+            {
+                return KubernetesClientConfiguration.BuildConfigFromConfigFile(null, Environment.GetEnvironmentVariable("KUBECONFIG"));
+            }
+            if (File.Exists("minikube.config"))
+            {
+                // If you're using minikube, things can get akward if you import the root CA in the Trusted Root Certificate Authorities list
+                // and re-create your cluster. Certificates issued will be rejected by Windows because the DN of the root CA doesn't change;
+                // yet the certificate will have a different signature.
+                return KubernetesClientConfiguration.BuildConfigFromConfigFile(null, "minikube.config");
+            }
+            else
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public static Task<IPEndPoint> GetEndPoint()
+        {
+            var configuration = Configure();
+            var kubernetes = new Kubernetes(configuration);
+            TillerLocator locator = new TillerLocator(kubernetes);
+            return locator.Locate();
+        }
+
+        public static async Task<Socket> GetSocket()
+        {
+            var endPoint = await GetEndPoint().ConfigureAwait(false);
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            await socket.ConnectAsync(endPoint).ConfigureAwait(false);
+            return socket;
+        }
+    }
+}

--- a/src/Helm.IntegrationTests/TillerClientTests.cs
+++ b/src/Helm.IntegrationTests/TillerClientTests.cs
@@ -1,0 +1,25 @@
+﻿using Helm.Helm;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Helm.IntegrationTests
+{
+    public class TillerClientTests
+    {
+        [Fact]
+        public async Task GetVersionStreamTest()
+        {
+            using (var socket = await TestConfiguration.GetSocket())
+            {
+                using (NetworkStream stream = new NetworkStream(socket))
+                {
+                    TillerClient client = new TillerClient(stream);
+                    var version = await client.GetVersionAsync();
+                    Assert.NotNull(version);
+                }
+            }
+        }
+    }
+}

--- a/src/Helm.IntegrationTests/TillerLocatorTests.cs
+++ b/src/Helm.IntegrationTests/TillerLocatorTests.cs
@@ -1,0 +1,20 @@
+﻿using Helm.Helm;
+using k8s;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Helm.IntegrationTests
+{
+    public class TillerLocatorTests
+    {
+        [Fact]
+        public async Task LocateTest()
+        {
+            Kubernetes kubernetes = new Kubernetes(TestConfiguration.Configure());
+
+            TillerLocator locator = new TillerLocator(kubernetes);
+            var endPoint = await locator.Locate().ConfigureAwait(false);
+            Assert.NotNull(endPoint);
+        }
+    }
+}

--- a/src/Helm.Tests/Helm.Tests.csproj
+++ b/src/Helm.Tests/Helm.Tests.csproj
@@ -15,5 +15,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Helm\Helm.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Helm.Tests/TillerClientTests.cs
+++ b/src/Helm.Tests/TillerClientTests.cs
@@ -9,34 +9,12 @@ namespace Helm.Tests
 {
     public class TillerClientTests
     {
+        private static readonly IPEndPoint tillerEndpoint = new IPEndPoint(IPAddress.Parse("172.17.0.3"), 44134);
+
         [Fact]
         public void ConstructorNullTest()
         {
             Assert.Throws<ArgumentNullException>(() => new TillerClient((string)null));
-        }
-
-        [Fact(Skip = "Live test")]
-        public async Task GetVersionTest()
-        {
-            TillerClient client = new TillerClient();
-            var version = await client.GetVersionAsync();
-            Assert.NotNull(version);
-        }
-
-        [Fact(Skip = "Live test")]
-        public async Task GetVersionStreamTest()
-        {
-            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            {
-                await socket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, 44134)).ConfigureAwait(false);
-
-                using (NetworkStream stream = new NetworkStream(socket))
-                {
-                    TillerClient client = new TillerClient(stream);
-                    var version = await client.GetVersionAsync();
-                    Assert.NotNull(version);
-                }
-            }
         }
     }
 }

--- a/src/Helm.sln
+++ b/src/Helm.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Helm", "Helm\Helm.csproj", "{563B765F-9CA8-4376-974B-0536B1882965}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Helm.Tests", "Helm.Tests\Helm.Tests.csproj", "{F3B1F110-923C-44EA-9B31-4AC26D1A8BC8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Helm.IntegrationTests", "Helm.IntegrationTests\Helm.IntegrationTests.csproj", "{774332CE-C6A8-4CCF-9D4E-6B66885A039F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +43,18 @@ Global
 		{F3B1F110-923C-44EA-9B31-4AC26D1A8BC8}.Release|x64.Build.0 = Release|Any CPU
 		{F3B1F110-923C-44EA-9B31-4AC26D1A8BC8}.Release|x86.ActiveCfg = Release|Any CPU
 		{F3B1F110-923C-44EA-9B31-4AC26D1A8BC8}.Release|x86.Build.0 = Release|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Debug|x64.Build.0 = Debug|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Debug|x86.Build.0 = Debug|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Release|x64.ActiveCfg = Release|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Release|x64.Build.0 = Release|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Release|x86.ActiveCfg = Release|Any CPU
+		{774332CE-C6A8-4CCF-9D4E-6B66885A039F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Helm/Helm.csproj
+++ b/src/Helm/Helm.csproj
@@ -25,6 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="http2dotnet" Version="0.8.0" />
+    <PackageReference Include="KubernetesClient" Version="0.4.0-beta" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.16">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Helm/Helm/StreamCallInvoker.cs
+++ b/src/Helm/Helm/StreamCallInvoker.cs
@@ -42,7 +42,6 @@ namespace Helm.Helm
             // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
             // When debugging, be aware of the timeouts!
             // You can get some insights about what's going on by running kubectl logs <tiller> -n kube-system -f
-
             ConnectionConfiguration config =
                new ConnectionConfigurationBuilder(isServer: false)
                .Build();

--- a/src/Helm/Helm/TillerLocator.cs
+++ b/src/Helm/Helm/TillerLocator.cs
@@ -1,0 +1,30 @@
+﻿using k8s;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Helm.Helm
+{
+    public class TillerLocator
+    {
+        private readonly IKubernetes kubernetes;
+
+        public TillerLocator(IKubernetes kubernetes)
+        {
+            this.kubernetes = kubernetes ?? throw new ArgumentNullException(nameof(kubernetes));
+        }
+
+        public async Task<IPEndPoint> Locate(string @namespace = "kube-system")
+        {
+            var tillerPods = await this.kubernetes.ListNamespacedPodAsync(@namespace, labelSelector: "app=helm,name=tiller").ConfigureAwait(false);
+
+            if (tillerPods.Items.Count == 0)
+            {
+                throw new TillerNotFoundException();
+            }
+
+            var tillerPod = tillerPods.Items[0];
+            return new IPEndPoint(IPAddress.Parse(tillerPod.Status.PodIP), 44134);
+        }
+    }
+}

--- a/src/Helm/Helm/TillerNotFoundException.cs
+++ b/src/Helm/Helm/TillerNotFoundException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Helm.Helm
+{
+    [Serializable]
+    public class TillerNotFoundException : Exception
+    {
+        public TillerNotFoundException()
+            : this("Could not found the Tiller pod")
+        {
+        }
+
+        public TillerNotFoundException(string message)
+            : base(message)
+        {
+        }
+
+        public TillerNotFoundException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected TillerNotFoundException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Helm/Helm/TillerNotFoundException.cs
+++ b/src/Helm/Helm/TillerNotFoundException.cs
@@ -7,7 +7,7 @@ namespace Helm.Helm
     public class TillerNotFoundException : Exception
     {
         public TillerNotFoundException()
-            : this("Could not found the Tiller pod")
+            : this("Could not find the Tiller pod in the Kubernetes cluster. Make sure Helm has been installed correctly.")
         {
         }
 


### PR DESCRIPTION
Before you can interact with Helm in a cluster, you need to find the Tiller pod. This PR adds support for that, you can now do:

```csharp
TillerLocator locator = new TillerLocator(kubernetes);
var endPoint = locator.Locate();
```

to find the IP endpoint at which Tiller is listening.

This PR also sets up integration testing in a minikube cluster running in a Travis CI job.