### PR TITLE
Actually implement ListRelease

### DIFF
--- a/src/Helm/Helm/AsyncStreamReader.cs
+++ b/src/Helm/Helm/AsyncStreamReader.cs
@@ -1,0 +1,40 @@
+﻿using Grpc.Core;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Helm.Helm
+{
+    internal class AsyncStreamReader<T> : IAsyncStreamReader<T>
+    {
+        private readonly AsyncUnaryCall<T> unaryCall;
+        private bool read = false;
+
+        public AsyncStreamReader(AsyncUnaryCall<T> unaryCall)
+        {
+            this.unaryCall = unaryCall ?? throw new ArgumentNullException(nameof(unaryCall));
+        }
+
+        public T Current
+        {
+            get;
+            set;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public async Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            if (!this.read)
+            {
+                this.Current = await this.unaryCall.ResponseAsync.ConfigureAwait(false);
+                this.read = true;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Helm/Helm/StreamCallInvoker.cs
+++ b/src/Helm/Helm/StreamCallInvoker.cs
@@ -36,7 +36,14 @@ namespace Helm.Helm
 
         public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request)
         {
-            throw new NotImplementedException();
+            var unaryCall = this.AsyncUnaryCall(method, host, options, request);
+
+            return new AsyncServerStreamingCall<TResponse>(
+                responseStream: new AsyncStreamReader<TResponse>(unaryCall),
+                responseHeadersAsync: unaryCall.ResponseHeadersAsync,
+                getStatusFunc: unaryCall.GetStatus,
+                getTrailersFunc: unaryCall.GetTrailers,
+                disposeAction: unaryCall.Dispose);
         }
 
         public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request)

--- a/src/Helm/Helm/TillerClient.cs
+++ b/src/Helm/Helm/TillerClient.cs
@@ -88,13 +88,13 @@ namespace Helm.Helm
             return response;
         }
 
-        public async Task<Hapi.Version.Version> GetVersionAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Hapi.Version.Version> GetVersion(CancellationToken cancellationToken = default(CancellationToken))
         {
             var version = await this.client.GetVersionAsync(new GetVersionRequest(), this.GetDefaultHeaders(), cancellationToken: cancellationToken);
             return version.Version;
         }
 
-        public async Task<Hapi.Release.Release> InstallReleaseAsync(Chart chart, string values, string name, bool reuseName, string @namespace = "default", bool wait = false, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Hapi.Release.Release> InstallRelease(Chart chart, string values, string name, bool reuseName, string @namespace = "default", bool wait = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (chart == null)
             {
@@ -130,9 +130,9 @@ namespace Helm.Helm
 
         public async Task<List<Release>> ListReleases(
             string filter = null,
-            int limit = int.MaxValue,
+            int limit = 256,
             string @namespace = null,
-            string offset = null,
+            string offset = "",
             ListSort.Types.SortBy sortBy = ListSort.Types.SortBy.Name,
             ListSort.Types.SortOrder sortOrder = ListSort.Types.SortOrder.Asc,
             CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
Releases are streamed asynchronously by the server, but handle this as a unitary call.
Use correct default values for ListRelease and add unit tests for ListRelease.
Remove the `Async` suffix in a couple of function names.