### PR TITLE
Fix issue with Chart.yaml and values.yaml not being 0 length

### DIFF
--- a/src/Helm.Tests/ChartPackageBuilderTests.cs
+++ b/src/Helm.Tests/ChartPackageBuilderTests.cs
@@ -39,6 +39,11 @@ namespace Helm.Tests
                         Assert.Contains(archive.Entries, e => e.Key == "hello-world/templates/ingress.yaml");
                         Assert.Contains(archive.Entries, e => e.Key == "hello-world/templates/NOTES.txt");
                         Assert.Contains(archive.Entries, e => e.Key == "hello-world/templates/service.yaml");
+
+                        foreach(var entry in archive.Entries)
+                        {
+                            Assert.NotEqual(0, entry.Size);
+                        }
                     }
                 }
             }

--- a/src/Helm/Charts/ChartPackageBuilder.cs
+++ b/src/Helm/Charts/ChartPackageBuilder.cs
@@ -86,9 +86,12 @@ namespace Helm.Charts
             }
 
             using (var stream = new MemoryStream())
-            using (var textWriter = new StreamWriter(stream, Encoding.UTF8))
             {
-                this.serializer.Serialize(textWriter, value);
+                using (var textWriter = new StreamWriter(stream, Encoding.UTF8, bufferSize: 4096, leaveOpen: true))
+                {
+                    this.serializer.Serialize(textWriter, value);
+                }
+
                 stream.Position = 0;
                 writer.Write(path, stream);
             }


### PR DESCRIPTION
The `StreamWriter` buffers values and needs to be flushed to make sure _all_ data has been serialized properly. One way to achieve by re-ordering the `using` statements and making sure `.Dispose` is called before the stream is copied to the chart.