### PR TITLE
Various fixes

### DIFF
--- a/src/Helm.Tests/ChartPackageBuilderTests.cs
+++ b/src/Helm.Tests/ChartPackageBuilderTests.cs
@@ -39,6 +39,11 @@ namespace Helm.Tests
                         Assert.Contains(archive.Entries, e => e.Key == "hello-world/templates/ingress.yaml");
                         Assert.Contains(archive.Entries, e => e.Key == "hello-world/templates/NOTES.txt");
                         Assert.Contains(archive.Entries, e => e.Key == "hello-world/templates/service.yaml");
+
+                        foreach(var entry in archive.Entries)
+                        {
+                            Assert.NotEqual(0, entry.Size);
+                        }
                     }
                 }
             }

--- a/src/Helm/Charts/ChartPackageBuilder.cs
+++ b/src/Helm/Charts/ChartPackageBuilder.cs
@@ -49,7 +49,11 @@ namespace Helm.Charts
             {
                 var chartName = chart.Metadata.Name;
                 this.WriteObject(writer, $"{chartName}/Chart.yaml", chart.Metadata);
-                this.WriteString(writer, $"{chartName}/values.yaml", chart.Values.Raw);
+
+                if (!string.IsNullOrWhiteSpace(chart.Values.Raw))
+                {
+                    this.WriteString(writer, $"{chartName}/values.yaml", chart.Values.Raw);
+                }
 
                 foreach (var template in chart.Templates)
                 {
@@ -115,9 +119,14 @@ namespace Helm.Charts
             }
 
             using (var stream = new MemoryStream())
-            using (var textWriter = new StreamWriter(stream, Encoding.UTF8))
             {
-                textWriter.Write(value);
+                // Don't emit a BOM and use Unix-style line endings
+                using (StreamWriter textWriter = new StreamWriter(stream, new UTF8Encoding(false), bufferSize: 4096, leaveOpen: true))
+                {
+                    textWriter.NewLine = "\n";
+                    textWriter.Write(value);
+                }
+
                 stream.Position = 0;
                 writer.Write(path, stream);
             }

--- a/src/Helm/Charts/ChartPackageBuilder.cs
+++ b/src/Helm/Charts/ChartPackageBuilder.cs
@@ -86,9 +86,12 @@ namespace Helm.Charts
             }
 
             using (var stream = new MemoryStream())
-            using (var textWriter = new StreamWriter(stream, Encoding.UTF8))
             {
-                this.serializer.Serialize(textWriter, value);
+                using (var textWriter = new StreamWriter(stream, Encoding.UTF8, bufferSize: 4096, leaveOpen: true))
+                {
+                    this.serializer.Serialize(textWriter, value);
+                }
+
                 stream.Position = 0;
                 writer.Write(path, stream);
             }

--- a/src/Helm/Helm/TillerClient.cs
+++ b/src/Helm/Helm/TillerClient.cs
@@ -135,6 +135,7 @@ namespace Helm.Helm
             string offset = "",
             ListSort.Types.SortBy sortBy = ListSort.Types.SortBy.Name,
             ListSort.Types.SortOrder sortOrder = ListSort.Types.SortOrder.Asc,
+            IEnumerable<Hapi.Release.Status.Types.Code> statusCodes = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             ListReleasesRequest request = new ListReleasesRequest()
@@ -146,6 +147,11 @@ namespace Helm.Helm
                 SortBy = sortBy,
                 SortOrder = sortOrder
             };
+
+            if (statusCodes != null)
+            {
+                request.StatusCodes.AddRange(statusCodes);
+            }
 
             var response = this.client.ListReleases(request, this.GetDefaultHeaders(), cancellationToken: cancellationToken);
 


### PR DESCRIPTION
- Make sure all content of a `TextWriter` is flushed by disposing of the `TextWriter` before working with its output
- Don't emit a BOM (which Helm doesn't like)
- Always use Linux (`\n`) line endings
- Support listing releases with specific status codes