### PR TITLE
Add a constructor

### DIFF
--- a/src/Helm/Helm/TillerClient.cs
+++ b/src/Helm/Helm/TillerClient.cs
@@ -23,6 +23,11 @@ namespace Helm.Helm
             this.client = new ReleaseServiceClient(new Channel(target, ChannelCredentials.Insecure));
         }
 
+        public TillerClient(Channel channel) 
+        {
+            this.client = new ReleaseServiceClient(channel); 
+        } 
+        
         public TillerClient(CallInvoker callInvoker)
         {
             this.client = new ReleaseServiceClient(callInvoker);


### PR DESCRIPTION
Adding a constructor that accepts a GrpcCore.Channel instance to enable users to be able to provide their own created channel.